### PR TITLE
improvement: turn on AQE for better partitioning

### DIFF
--- a/changelog/@unreleased/pr-191.v2.yml
+++ b/changelog/@unreleased/pr-191.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Turn on AQE for better partitioning
+
+    Downside is that this will also apply to the queries - I can refactor the code to take different spark configs for those if needed, but if we run the queries enough times, we should be able to account for any differences because of the non determinism?
+  links:
+  - https://github.com/palantir/spark-tpcds-benchmark/pull/191

--- a/spark-tpcds-benchmark-runner/var/conf/config.yml
+++ b/spark-tpcds-benchmark-runner/var/conf/config.yml
@@ -15,6 +15,7 @@ spark:
   master: local[4]
   sparkConf:
     spark.yarn.jars: service/lib/*
+    spark.sql.adaptive.enabled: true
 #testDataDir: hdfs://localhost:8020/data/tpcds/test_data
 testDataDir: file:///tmp/hdfs/data/tpcds/test_data
 iterations: 1


### PR DESCRIPTION
Downside is that this will also apply to the queries - I can refactor the code to take different spark configs for those if needed, but if we run the queries enough times, we should be able to account for any differences because of the non determinism?