### PR TITLE
hive partition metrics to preclude conflicts

### DIFF
--- a/changelog/@unreleased/pr-241.v2.yml
+++ b/changelog/@unreleased/pr-241.v2.yml
@@ -1,6 +1,7 @@
 type: improvement
 improvement:
   description: Results metrics will always be written to a unique path, since they
-    are hive partitioned by sessionId (a random UUID).
+    are hive partitioned by sessionId (a random UUID), as well as iteration & attempt
+    numbers.
   links:
   - https://github.com/palantir/spark-tpcds-benchmark/pull/241

--- a/changelog/@unreleased/pr-241.v2.yml
+++ b/changelog/@unreleased/pr-241.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Results metrics will always be written to a unique path, since they
+    are hive partitioned by sessionId (a random UUID).
+  links:
+  - https://github.com/palantir/spark-tpcds-benchmark/pull/241

--- a/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/Benchmark.java
+++ b/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/Benchmark.java
@@ -106,6 +106,7 @@ public final class Benchmark {
                     "Beginning benchmark iteration {} of {}.",
                     SafeArg.of("currentIteration", iteration),
                     SafeArg.of("totalNumIterations", config.benchmarks().iterations()));
+            attemptCounters.clear();
             config.dataScalesGb().forEach(scale -> {
                 log.info("Beginning benchmarks at a new data scale of {}.", SafeArg.of("dataScale", scale));
                 registration.registerTpcdsTables(scale);
@@ -154,7 +155,7 @@ public final class Benchmark {
     }
 
     private boolean attemptQuery(Query query, Integer scale) {
-        QuerySessionIdentifier identifier = QuerySessionIdentifier.create(query.getName(), scale);
+        QuerySessionIdentifier identifier = QuerySessionIdentifier.createDefault(query.getName(), scale);
         int attempt =
                 attemptCounters.compute(identifier, (_key, oldAttempts) -> oldAttempts == null ? 0 : oldAttempts + 1);
         log.info(

--- a/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/Benchmark.java
+++ b/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/Benchmark.java
@@ -22,12 +22,14 @@ import com.github.rholder.retry.StopStrategies;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
 import com.google.common.io.CharStreams;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.spark.benchmark.config.BenchmarkRunnerConfig;
 import com.palantir.spark.benchmark.correctness.TpcdsQueryCorrectnessChecks;
 import com.palantir.spark.benchmark.datagen.SortDataGenerator;
 import com.palantir.spark.benchmark.datagen.TpcdsDataGenerator;
+import com.palantir.spark.benchmark.metrics.BenchmarkMetric;
 import com.palantir.spark.benchmark.metrics.BenchmarkMetrics;
 import com.palantir.spark.benchmark.paths.BenchmarkPaths;
 import com.palantir.spark.benchmark.queries.Query;
@@ -43,6 +45,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.hadoop.fs.FileSystem;
@@ -106,16 +109,16 @@ public final class Benchmark {
                     "Beginning benchmark iteration {} of {}.",
                     SafeArg.of("currentIteration", iteration),
                     SafeArg.of("totalNumIterations", config.benchmarks().iterations()));
-            attemptCounters.clear();
-            config.dataScalesGb().forEach(scale -> {
-                log.info("Beginning benchmarks at a new data scale of {}.", SafeArg.of("dataScale", scale));
-                registration.registerTpcdsTables(scale);
-                registration.registerGensortTable(scale);
-                getQueries()
-                        .forEach(query -> runQueryWithRetries(
-                                query, scale, config.benchmarks().attemptsPerQuery()));
-                log.info("Successfully ran benchmarks at scale of {} GB.", SafeArg.of("scale", scale));
-            });
+            Streams.forEachPair(
+                    config.dataScalesGb().stream(), Stream.generate(Suppliers.ofInstance(iteration)), (scale, iter) -> {
+                        log.info("Beginning benchmarks at a new data scale of {}.", SafeArg.of("dataScale", scale));
+                        registration.registerTpcdsTables(scale);
+                        registration.registerGensortTable(scale);
+                        getQueries()
+                                .forEach(query -> runQueryWithRetries(
+                                        query, scale, iter, config.benchmarks().attemptsPerQuery()));
+                        log.info("Successfully ran benchmarks at scale of {} GB.", SafeArg.of("scale", scale));
+                    });
             log.info(
                     "Successfully finished an iteration of benchmarks at all scales. Completed {} iterations in total.",
                     SafeArg.of("completedIterations", iteration));
@@ -123,7 +126,10 @@ public final class Benchmark {
         log.info("Successfully ran all benchmarks for the requested number of iterations");
 
         metrics.flushMetrics();
-        Dataset<Row> resultMetrics = spark.read().json(paths.metricsDir()).drop("sparkConf");
+        Dataset<Row> resultMetrics = spark.read()
+                .schema(BenchmarkMetric.schema())
+                .json(paths.metricsDir())
+                .drop("sparkConf");
         log.info(
                 "Printing summary metrics (limit 1000):\n{}",
                 SafeArg.of(
@@ -135,7 +141,7 @@ public final class Benchmark {
         log.info("Finished benchmark; exiting");
     }
 
-    private void runQueryWithRetries(Query query, Integer scale, int numAttempts) {
+    private void runQueryWithRetries(Query query, int scale, int iteration, int numAttempts) {
         try {
             RetryerBuilder.<Boolean>newBuilder()
                     .retryIfException()
@@ -143,19 +149,20 @@ public final class Benchmark {
                     .retryIfResult(succeeded -> succeeded == null || !succeeded)
                     .withStopStrategy(StopStrategies.stopAfterAttempt(numAttempts))
                     .build()
-                    .call(() -> attemptQuery(query, scale));
+                    .call(() -> attemptQuery(query, scale, iteration));
         } catch (RetryException | ExecutionException e) {
             log.error(
-                    "Failed to execute query {} at scale {} on all {} attempts",
+                    "Failed to execute query {} at scale {} on all {} attempts in iteration {}",
                     SafeArg.of("query", query.getName()),
                     SafeArg.of("scale", scale),
                     SafeArg.of("numAttempts", numAttempts),
+                    SafeArg.of("iteration", iteration),
                     e);
         }
     }
 
-    private boolean attemptQuery(Query query, Integer scale) {
-        QuerySessionIdentifier identifier = QuerySessionIdentifier.createDefault(query.getName(), scale);
+    private boolean attemptQuery(Query query, int scale, int iteration) {
+        QuerySessionIdentifier identifier = QuerySessionIdentifier.createDefault(query.getName(), scale, iteration);
         int attempt =
                 attemptCounters.compute(identifier, (_key, oldAttempts) -> oldAttempts == null ? 0 : oldAttempts + 1);
         log.info(
@@ -172,21 +179,23 @@ public final class Benchmark {
             }
 
             spark.sparkContext().setJobDescription(String.format("%s-benchmark-attempt-%d", query.getName(), attempt));
-            metrics.startBenchmark(identifier);
+            metrics.startBenchmark(identifier, attempt);
             query.save(resultLocation);
-            metrics.stopBenchmark(identifier);
+            metrics.stopBenchmark(identifier, attempt);
             log.info(
-                    "Successfully ran query {} at scale {}.",
+                    "Successfully ran query {} at scale {} on attempt {}.",
                     SafeArg.of("queryName", query.getName()),
-                    SafeArg.of("scale", scale));
+                    SafeArg.of("scale", scale),
+                    SafeArg.of("attempt", attempt));
             verifyCorrectness(query, identifier, resultLocation);
             return true;
         } catch (Exception e) {
-            metrics.abortBenchmark(identifier);
+            metrics.abortBenchmark(identifier, attempt);
             log.error(
-                    "Caught an exception while running query {} at scale {}; may re-attempt.",
+                    "Caught an exception while running query {} at scale {} on attempt {}; may re-attempt.",
                     SafeArg.of("queryName", query.getName()),
                     SafeArg.of("scale", scale),
+                    SafeArg.of("attempt", attempt),
                     e);
             return false;
         }

--- a/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/metrics/BenchmarkMetric.java
+++ b/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/metrics/BenchmarkMetric.java
@@ -68,6 +68,10 @@ public abstract class BenchmarkMetric implements Serializable {
 
     public abstract Optional<String> sessionId();
 
+    public abstract Optional<Integer> iteration();
+
+    public abstract Optional<Integer> attempt();
+
     public static StructType schema() {
         return new StructType(Stream.of(
                         new StructField("experimentName", DataTypes.StringType, false, Metadata.empty()),
@@ -87,7 +91,9 @@ public abstract class BenchmarkMetric implements Serializable {
                         new StructField("experimentStartTimestamp", DataTypes.TimestampType, false, Metadata.empty()),
                         new StructField("experimentEndTimestamp", DataTypes.TimestampType, false, Metadata.empty()),
                         new StructField("failedVerification", DataTypes.BooleanType, true, Metadata.empty()),
-                        new StructField("sessionId", DataTypes.StringType, true, Metadata.empty()))
+                        new StructField("sessionId", DataTypes.StringType, true, Metadata.empty()),
+                        new StructField("iteration", DataTypes.IntegerType, true, Metadata.empty()),
+                        new StructField("attempt", DataTypes.IntegerType, true, Metadata.empty()))
                 .toArray(StructField[]::new));
     }
 
@@ -106,7 +112,9 @@ public abstract class BenchmarkMetric implements Serializable {
                         new java.sql.Timestamp(experimentStartTimestampMillis()),
                         new java.sql.Timestamp(experimentEndTimestampMillis()),
                         failedVerification().orElse(false),
-                        sessionId().orElse(QuerySessionIdentifier.NO_SESSION)))
+                        sessionId().orElse(QuerySessionIdentifier.NO_SESSION),
+                        iteration().orElse(-1),
+                        attempt().orElse(-1)))
                 .asScala());
     }
 

--- a/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/metrics/BenchmarkMetric.java
+++ b/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/metrics/BenchmarkMetric.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableList;
 import com.palantir.spark.benchmark.immutables.ImmutablesStyle;
+import com.palantir.spark.benchmark.queries.QuerySessionIdentifier;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Optional;
@@ -105,7 +106,7 @@ public abstract class BenchmarkMetric implements Serializable {
                         new java.sql.Timestamp(experimentStartTimestampMillis()),
                         new java.sql.Timestamp(experimentEndTimestampMillis()),
                         failedVerification().orElse(false),
-                        sessionId().orElse("NO_SESSION")))
+                        sessionId().orElse(QuerySessionIdentifier.NO_SESSION)))
                 .asScala());
     }
 

--- a/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/metrics/BenchmarkMetric.java
+++ b/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/metrics/BenchmarkMetric.java
@@ -65,6 +65,8 @@ public abstract class BenchmarkMetric implements Serializable {
 
     public abstract Optional<Boolean> failedVerification();
 
+    public abstract Optional<String> sessionId();
+
     public static StructType schema() {
         return new StructType(Stream.of(
                         new StructField("experimentName", DataTypes.StringType, false, Metadata.empty()),
@@ -83,7 +85,8 @@ public abstract class BenchmarkMetric implements Serializable {
                                 Metadata.empty()),
                         new StructField("experimentStartTimestamp", DataTypes.TimestampType, false, Metadata.empty()),
                         new StructField("experimentEndTimestamp", DataTypes.TimestampType, false, Metadata.empty()),
-                        new StructField("failedVerification", DataTypes.BooleanType, true, Metadata.empty()))
+                        new StructField("failedVerification", DataTypes.BooleanType, true, Metadata.empty()),
+                        new StructField("sessionId", DataTypes.StringType, true, Metadata.empty()))
                 .toArray(StructField[]::new));
     }
 
@@ -101,7 +104,8 @@ public abstract class BenchmarkMetric implements Serializable {
                         JavaConverters.mapAsScalaMapConverter(sparkConf()).asScala(),
                         new java.sql.Timestamp(experimentStartTimestampMillis()),
                         new java.sql.Timestamp(experimentEndTimestampMillis()),
-                        failedVerification().orElse(false)))
+                        failedVerification().orElse(false),
+                        sessionId().orElse("NO_SESSION")))
                 .asScala());
     }
 

--- a/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/metrics/BenchmarkMetrics.java
+++ b/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/metrics/BenchmarkMetrics.java
@@ -126,6 +126,7 @@ public final class BenchmarkMetrics {
                         .experimentStartTimestampMillis(startTime.toEpochMilli())
                         .experimentEndTimestampMillis(endTime.toEpochMilli())
                         .durationMillis(elapsed)
+                        .sessionId(runningQuery.identifier().session())
                         .build());
         currentRunningQuery = Optional.empty();
     }
@@ -158,7 +159,12 @@ public final class BenchmarkMetrics {
     }
 
     public void flushMetrics() {
-        getMetricsDataset().write().mode(SaveMode.Append).format("json").save(paths.metricsDir());
+        getMetricsDataset()
+                .write()
+                .partitionBy("sessionId")
+                .mode(SaveMode.Append)
+                .format("json")
+                .save(paths.metricsDir());
         metricsBuffer.clear();
         MAP_DB.commit();
     }

--- a/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/metrics/BenchmarkMetrics.java
+++ b/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/metrics/BenchmarkMetrics.java
@@ -88,22 +88,24 @@ public final class BenchmarkMetrics {
                 .make();
     }
 
-    public void startBenchmark(QuerySessionIdentifier identifier) {
+    public void startBenchmark(QuerySessionIdentifier identifier, int attempt) {
         Preconditions.checkArgument(currentRunningQuery.isEmpty(), "Can only run one query at a time.");
         currentRunningQuery = Optional.of(RunningQuery.builder()
                 .timer(Stopwatch.createStarted())
                 .identifier(identifier)
+                .attempt(attempt)
                 .build());
     }
 
-    public void stopBenchmark(QuerySessionIdentifier identifier) {
+    public void stopBenchmark(QuerySessionIdentifier identifier, int attempt) {
         Preconditions.checkArgument(currentRunningQuery.isPresent(), "No benchmark is currently running.");
         RunningQuery runningQuery = currentRunningQuery.get();
-        Preconditions.checkState(
-                runningQuery.identifier().equals(identifier),
+        Preconditions.checkArgument(
+                runningQuery.identifier().equals(identifier) && runningQuery.attempt() == attempt,
                 "Query identifiers must match",
-                SafeArg.of("currentlyRunningIdentifier", runningQuery.identifier()),
-                SafeArg.of("identifier", identifier));
+                SafeArg.of("runningQuery", runningQuery),
+                SafeArg.of("identifier", identifier),
+                SafeArg.of("attempt", attempt));
 
         Instant endTime = Instant.now();
         long elapsed = runningQuery.timer().elapsed(TimeUnit.MILLISECONDS);
@@ -127,18 +129,21 @@ public final class BenchmarkMetrics {
                         .experimentEndTimestampMillis(endTime.toEpochMilli())
                         .durationMillis(elapsed)
                         .sessionId(runningQuery.identifier().session())
+                        .iteration(runningQuery.identifier().iteration())
+                        .attempt(attempt)
                         .build());
         currentRunningQuery = Optional.empty();
     }
 
-    public void abortBenchmark(QuerySessionIdentifier identifier) {
-        currentRunningQuery.ifPresent(query -> {
-            Preconditions.checkState(
-                    query.identifier().equals(identifier),
+    public void abortBenchmark(QuerySessionIdentifier identifier, int attempt) {
+        currentRunningQuery.ifPresent(runningQuery -> {
+            Preconditions.checkArgument(
+                    runningQuery.identifier().equals(identifier) && runningQuery.attempt() == attempt,
                     "Query identifiers must match",
-                    SafeArg.of("currentlyRunningIdentifier", query.identifier()),
-                    SafeArg.of("identifier", identifier));
-            query.timer().stop();
+                    SafeArg.of("runningQuery", runningQuery),
+                    SafeArg.of("identifier", identifier),
+                    SafeArg.of("attempt", attempt));
+            runningQuery.timer().stop();
         });
         currentRunningQuery = Optional.empty();
     }
@@ -161,7 +166,7 @@ public final class BenchmarkMetrics {
     public void flushMetrics() {
         getMetricsDataset()
                 .write()
-                .partitionBy("sessionId")
+                .partitionBy("sessionId", "iteration", "attempt")
                 .mode(SaveMode.Append)
                 .format("json")
                 .save(paths.metricsDir());
@@ -179,6 +184,8 @@ public final class BenchmarkMetrics {
     @ImmutablesStyle
     interface RunningQuery {
         QuerySessionIdentifier identifier();
+
+        int attempt();
 
         @Value.Auxiliary
         Stopwatch timer();

--- a/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/queries/QuerySessionIdentifier.java
+++ b/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/queries/QuerySessionIdentifier.java
@@ -36,6 +36,9 @@ public interface QuerySessionIdentifier {
     @Value.Parameter
     int scale();
 
+    @Value.Parameter
+    int iteration();
+
     @Value.Default
     default String session() {
         return SESSION_ID;
@@ -47,15 +50,7 @@ public interface QuerySessionIdentifier {
         return new Builder();
     }
 
-    static QuerySessionIdentifier createDefault(String queryName, int scale) {
-        return builder().queryName(queryName).scale(scale).build();
-    }
-
-    static QuerySessionIdentifier createUnique(String queryName, int scale) {
-        return builder()
-                .queryName(queryName)
-                .scale(scale)
-                .session(UUID.randomUUID().toString())
-                .build();
+    static QuerySessionIdentifier createDefault(String queryName, int scale, int iteration) {
+        return builder().queryName(queryName).scale(scale).iteration(iteration).build();
     }
 }

--- a/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/queries/QuerySessionIdentifier.java
+++ b/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/queries/QuerySessionIdentifier.java
@@ -48,11 +48,7 @@ public interface QuerySessionIdentifier {
     }
 
     static QuerySessionIdentifier createDefault(String queryName, int scale) {
-        return builder()
-                .queryName(queryName)
-                .scale(scale)
-                .session(UUID.randomUUID().toString())
-                .build();
+        return builder().queryName(queryName).scale(scale).build();
     }
 
     static QuerySessionIdentifier createUnique(String queryName, int scale) {

--- a/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/queries/QuerySessionIdentifier.java
+++ b/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/queries/QuerySessionIdentifier.java
@@ -27,14 +27,18 @@ import org.immutables.value.Value;
 @JsonSerialize(as = ImmutableQuerySessionIdentifier.class)
 @JsonDeserialize(as = ImmutableQuerySessionIdentifier.class)
 public interface QuerySessionIdentifier {
+    String SESSION_ID = UUID.randomUUID().toString();
+
     @Value.Parameter
     String queryName();
 
     @Value.Parameter
     int scale();
 
-    @Value.Parameter
-    String session();
+    @Value.Default
+    default String session() {
+        return SESSION_ID;
+    }
 
     final class Builder extends ImmutableQuerySessionIdentifier.Builder {}
 
@@ -42,7 +46,15 @@ public interface QuerySessionIdentifier {
         return new Builder();
     }
 
-    static QuerySessionIdentifier create(String queryName, int scale) {
+    static QuerySessionIdentifier createDefault(String queryName, int scale) {
+        return builder()
+                .queryName(queryName)
+                .scale(scale)
+                .session(UUID.randomUUID().toString())
+                .build();
+    }
+
+    static QuerySessionIdentifier createUnique(String queryName, int scale) {
         return builder()
                 .queryName(queryName)
                 .scale(scale)

--- a/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/queries/QuerySessionIdentifier.java
+++ b/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/queries/QuerySessionIdentifier.java
@@ -27,6 +27,7 @@ import org.immutables.value.Value;
 @JsonSerialize(as = ImmutableQuerySessionIdentifier.class)
 @JsonDeserialize(as = ImmutableQuerySessionIdentifier.class)
 public interface QuerySessionIdentifier {
+    String NO_SESSION = "NO_SESSION";
     String SESSION_ID = UUID.randomUUID().toString();
 
     @Value.Parameter

--- a/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/AbstractLocalSparkTest.java
+++ b/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/AbstractLocalSparkTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.spark.benchmark.datagen;
+package com.palantir.spark.benchmark;
 
 import com.palantir.spark.benchmark.config.HadoopConfiguration;
 import com.palantir.spark.benchmark.config.SimpleFilesystemConfiguration;
@@ -27,7 +27,7 @@ import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.BeforeEach;
 
 public abstract class AbstractLocalSparkTest {
-    SparkSession sparkSession;
+    protected SparkSession sparkSession;
 
     @BeforeEach
     public void beforeEach() {
@@ -46,13 +46,13 @@ public abstract class AbstractLocalSparkTest {
                 .getOrCreate();
     }
 
-    final Path createTemporaryWorkingDir(String prefix) throws IOException {
+    protected final Path createTemporaryWorkingDir(String prefix) throws IOException {
         Path directory = Files.createDirectory(Paths.get("/tmp", prefix + "_" + UUID.randomUUID()));
         directory.toFile().deleteOnExit();
         return directory;
     }
 
-    final HadoopConfiguration getHadoopConfiguration(Path destinationDataDirectory) {
+    protected final HadoopConfiguration getHadoopConfiguration(Path destinationDataDirectory) {
         String fullyQualifiedDestinationDir =
                 "file://" + destinationDataDirectory.toFile().getAbsolutePath();
         return HadoopConfiguration.builder()

--- a/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/TestIdentifiers.java
+++ b/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/TestIdentifiers.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.spark.benchmark;
+
+import com.palantir.spark.benchmark.queries.QuerySessionIdentifier;
+import java.util.UUID;
+
+public final class TestIdentifiers {
+    private TestIdentifiers() {}
+
+    public static QuerySessionIdentifier create(String queryName, int scale) {
+        return QuerySessionIdentifier.builder()
+                .queryName(queryName)
+                .scale(scale)
+                .iteration(0)
+                .session(UUID.randomUUID().toString())
+                .build();
+    }
+}

--- a/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/datagen/BenchmarkMetricsTest.java
+++ b/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/datagen/BenchmarkMetricsTest.java
@@ -37,12 +37,12 @@ public final class BenchmarkMetricsTest extends AbstractLocalSparkTest {
         BenchmarkPaths paths = new BenchmarkPaths(experimentName);
         BenchmarkMetrics metrics =
                 new BenchmarkMetrics(SparkConfiguration.builder().build(), experimentName, paths, sparkSession);
-        QuerySessionIdentifier identifier1 = QuerySessionIdentifier.create("q1", 10);
+        QuerySessionIdentifier identifier1 = QuerySessionIdentifier.createDefault("q1", 10);
         metrics.startBenchmark(identifier1);
         metrics.stopBenchmark(identifier1);
         metrics.markVerificationFailed(identifier1);
 
-        QuerySessionIdentifier identifier2 = QuerySessionIdentifier.create("q2", 10);
+        QuerySessionIdentifier identifier2 = QuerySessionIdentifier.createDefault("q2", 10);
         metrics.startBenchmark(identifier2);
         metrics.stopBenchmark(identifier2);
 

--- a/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/datagen/BenchmarkMetricsTest.java
+++ b/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/datagen/BenchmarkMetricsTest.java
@@ -19,19 +19,24 @@ package com.palantir.spark.benchmark.datagen;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.spark.benchmark.config.SparkConfiguration;
+import com.palantir.spark.benchmark.metrics.BenchmarkMetric;
 import com.palantir.spark.benchmark.metrics.BenchmarkMetrics;
 import com.palantir.spark.benchmark.paths.BenchmarkPaths;
 import com.palantir.spark.benchmark.queries.QuerySessionIdentifier;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
+import org.apache.spark.sql.Row;
+import org.assertj.core.util.Files;
 import org.junit.jupiter.api.Test;
 
 public final class BenchmarkMetricsTest extends AbstractLocalSparkTest {
     @Test
     public void testMetrics() {
-        BenchmarkMetrics metrics = new BenchmarkMetrics(
-                SparkConfiguration.builder().build(),
-                "test-experiment",
-                new BenchmarkPaths("test-experiment"),
-                sparkSession);
+        String experimentName = "test-experiment-" + UUID.randomUUID().toString();
+        BenchmarkPaths paths = new BenchmarkPaths(experimentName);
+        BenchmarkMetrics metrics =
+                new BenchmarkMetrics(SparkConfiguration.builder().build(), experimentName, paths, sparkSession);
         QuerySessionIdentifier identifier1 = QuerySessionIdentifier.create("q1", 10);
         metrics.startBenchmark(identifier1);
         metrics.stopBenchmark(identifier1);
@@ -40,9 +45,30 @@ public final class BenchmarkMetricsTest extends AbstractLocalSparkTest {
         QuerySessionIdentifier identifier2 = QuerySessionIdentifier.create("q2", 10);
         metrics.startBenchmark(identifier2);
         metrics.stopBenchmark(identifier2);
-        assertThat(metrics.getMetricsDataset().collectAsList()).hasSize(2);
+
+        // drop sparkConf for legibility on test failures
+        List<Row> metricsRows = metrics.getMetricsDataset().drop("sparkConf").collectAsList();
+        assertThat(metricsRows).hasSize(2);
         assertThat(metrics.getMetricsDataset().selectExpr("failedVerification").collectAsList().stream()
                         .map(row -> row.getBoolean(0)))
                 .containsExactlyInAnyOrder(true, false);
+        assertThat(metrics.getMetricsDataset().selectExpr("sessionId").collectAsList().stream()
+                        .map(row -> row.getString(0))
+                        .map(UUID::fromString)
+                        .distinct())
+                .hasSize(2);
+
+        metrics.flushMetrics();
+        assertThat(metrics.getMetricsDataset().collectAsList()).isEmpty();
+        assertThat(sparkSession
+                        .read()
+                        .schema(BenchmarkMetric.schema())
+                        .json(paths.metricsDir())
+                        .drop("sparkConf")
+                        .collectAsList())
+                .containsExactlyInAnyOrderElementsOf(metricsRows);
+
+        // clean up
+        Files.delete(Paths.get(paths.metricsDir()).toFile());
     }
 }

--- a/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/datagen/BenchmarkMetricsTest.java
+++ b/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/datagen/BenchmarkMetricsTest.java
@@ -18,6 +18,8 @@ package com.palantir.spark.benchmark.datagen;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.palantir.spark.benchmark.AbstractLocalSparkTest;
+import com.palantir.spark.benchmark.TestIdentifiers;
 import com.palantir.spark.benchmark.config.SparkConfiguration;
 import com.palantir.spark.benchmark.metrics.BenchmarkMetric;
 import com.palantir.spark.benchmark.metrics.BenchmarkMetrics;
@@ -37,14 +39,14 @@ public final class BenchmarkMetricsTest extends AbstractLocalSparkTest {
         BenchmarkPaths paths = new BenchmarkPaths(experimentName);
         BenchmarkMetrics metrics =
                 new BenchmarkMetrics(SparkConfiguration.builder().build(), experimentName, paths, sparkSession);
-        QuerySessionIdentifier identifier1 = QuerySessionIdentifier.createDefault("q1", 10);
-        metrics.startBenchmark(identifier1);
-        metrics.stopBenchmark(identifier1);
+        QuerySessionIdentifier identifier1 = TestIdentifiers.create("q1", 10);
+        metrics.startBenchmark(identifier1, 0);
+        metrics.stopBenchmark(identifier1, 0);
         metrics.markVerificationFailed(identifier1);
 
-        QuerySessionIdentifier identifier2 = QuerySessionIdentifier.createDefault("q2", 10);
-        metrics.startBenchmark(identifier2);
-        metrics.stopBenchmark(identifier2);
+        QuerySessionIdentifier identifier2 = TestIdentifiers.create("q2", 10);
+        metrics.startBenchmark(identifier2, 0);
+        metrics.stopBenchmark(identifier2, 0);
 
         // drop sparkConf for legibility on test failures
         List<Row> metricsRows = metrics.getMetricsDataset().drop("sparkConf").collectAsList();

--- a/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/datagen/GenSortTest.java
+++ b/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/datagen/GenSortTest.java
@@ -81,7 +81,7 @@ public final class GenSortTest extends AbstractLocalSparkTest {
 
         SortBenchmarkQuery query = new SortBenchmarkQuery(sparkSession);
         // Should not throw. We can't assert sortedness since the data could be saved in multiple partitions.
-        query.save(paths.experimentResultLocation(QuerySessionIdentifier.create("gensort", scale), 0));
+        query.save(paths.experimentResultLocation(QuerySessionIdentifier.createUnique("gensort", scale), 0));
     }
 
     private List<String> read(Path path, String format) {

--- a/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/datagen/GenSortTest.java
+++ b/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/datagen/GenSortTest.java
@@ -20,10 +20,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.spark.benchmark.AbstractLocalSparkTest;
+import com.palantir.spark.benchmark.TestIdentifiers;
 import com.palantir.spark.benchmark.config.HadoopConfiguration;
 import com.palantir.spark.benchmark.datagen.GenSortDataGenerator.ScaleAndRecords;
 import com.palantir.spark.benchmark.paths.BenchmarkPaths;
-import com.palantir.spark.benchmark.queries.QuerySessionIdentifier;
 import com.palantir.spark.benchmark.queries.SortBenchmarkQuery;
 import com.palantir.spark.benchmark.registration.TableRegistration;
 import com.palantir.spark.benchmark.schemas.Schemas;
@@ -81,7 +82,7 @@ public final class GenSortTest extends AbstractLocalSparkTest {
 
         SortBenchmarkQuery query = new SortBenchmarkQuery(sparkSession);
         // Should not throw. We can't assert sortedness since the data could be saved in multiple partitions.
-        query.save(paths.experimentResultLocation(QuerySessionIdentifier.createUnique("gensort", scale), 0));
+        query.save(paths.experimentResultLocation(TestIdentifiers.create("gensort", scale), 0));
     }
 
     private List<String> read(Path path, String format) {

--- a/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/datagen/TpcdsDataGeneratorIntegrationTest.java
+++ b/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/datagen/TpcdsDataGeneratorIntegrationTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.spark.benchmark.AbstractLocalSparkTest;
 import com.palantir.spark.benchmark.config.HadoopConfiguration;
 import com.palantir.spark.benchmark.paths.BenchmarkPaths;
 import com.palantir.spark.benchmark.schemas.Schemas;


### PR DESCRIPTION
## Before this PR
Writing results metrics could fail on conflict (or potentially overwrite old results rather than appending).

## After this PR
==COMMIT_MSG==
Results metrics will always be written to a unique path, since they are hive partitioned by (sessionId, iteration, attempt). The sessionId has been changed back to be a random UUID per JVM lifetime. 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

