### PR TITLE
increase YARN max executor failures in default config

### DIFF
--- a/changelog/@unreleased/pr-242.v2.yml
+++ b/changelog/@unreleased/pr-242.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: increase YARN max executor failures in default config, so benchmarks
+    with many iterations are less likely to fail
+  links:
+  - https://github.com/palantir/spark-tpcds-benchmark/pull/242

--- a/spark-tpcds-benchmark-runner/var/conf/config.yml
+++ b/spark-tpcds-benchmark-runner/var/conf/config.yml
@@ -28,6 +28,7 @@ spark:
   sparkConf:
     spark.yarn.jars: service/lib/*
     spark.sql.adaptive.enabled: true
+    spark.yarn.max.executor.failures: 1000
 
 dataScalesGb:
   - 1


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
increase YARN max executor failures in default config, so benchmarks with many iterations are less likely to fail
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

