### PR TITLE
separate data filesystem from default filesystem

### DIFF
--- a/changelog/@unreleased/pr-244.v2.yml
+++ b/changelog/@unreleased/pr-244.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: The data filesystem can be explicitly different from the default filesystem
+    (so that, e.g., results/metrics may be written to default fs instead of data fs).
+  links:
+  - https://github.com/palantir/spark-tpcds-benchmark/pull/244

--- a/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/BenchmarkRunner.java
+++ b/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/BenchmarkRunner.java
@@ -55,7 +55,7 @@ public final class BenchmarkRunner {
         BenchmarkRunnerConfig config = BenchmarkRunnerConfig.parse(configFile);
         Configuration hadoopConf = config.hadoop().toHadoopConf();
         try (FileSystem dataFileSystem =
-                FileSystems.createFileSystem(config.hadoop().defaultFsBaseUri(), hadoopConf)) {
+                FileSystems.createFileSystem(config.hadoop().dataFilesystemBaseUri(), hadoopConf)) {
             SparkConf sparkConf = new SparkConf().setMaster(config.spark().master());
             config.spark().sparkConf().forEach(sparkConf::set);
             hadoopConf.forEach(confEntry ->

--- a/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/config/HadoopConfiguration.java
+++ b/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/config/HadoopConfiguration.java
@@ -43,20 +43,14 @@ public interface HadoopConfiguration {
 
     String defaultFilesystem();
 
+    Optional<String> dataFilesystem();
+
     Map<String, FilesystemConfiguration> filesystems();
 
-    @Value.Derived
-    default String defaultFsBaseUriString() {
-        return Optional.ofNullable(filesystems().get(defaultFilesystem()))
-                .orElseThrow(() -> new SafeIllegalArgumentException(
-                        "Specified defaultFilesystem is not configured",
-                        SafeArg.of("defaultFilesystem", defaultFilesystem())))
-                .baseUri();
-    }
-
-    @Value.Derived
-    default URI defaultFsBaseUri() {
-        return new org.apache.hadoop.fs.Path(defaultFsBaseUriString()).toUri();
+    @Value.Lazy
+    default URI dataFilesystemBaseUri() {
+        String baseUri = getFilesystemBaseUriOrThrow(dataFilesystem().orElseGet(this::defaultFilesystem));
+        return new org.apache.hadoop.fs.Path(baseUri).toUri();
     }
 
     @Value.Derived
@@ -80,8 +74,15 @@ public interface HadoopConfiguration {
                         filesystems().values().stream().flatMap(fsConf -> fsConf.toHadoopConf().entrySet().stream()))
                 .collectToMap()
                 .forEach(hadoopConf::set);
-        hadoopConf.set(CommonConfigurationKeys.FS_DEFAULT_NAME_KEY, defaultFsBaseUriString());
+        hadoopConf.set(CommonConfigurationKeys.FS_DEFAULT_NAME_KEY, getFilesystemBaseUriOrThrow(defaultFilesystem()));
         return hadoopConf;
+    }
+
+    default String getFilesystemBaseUriOrThrow(String filesystemName) {
+        return Optional.ofNullable(filesystems().get(filesystemName))
+                .orElseThrow(() -> new SafeIllegalArgumentException(
+                        "Specified filesystem is not configured", SafeArg.of("filesystem", filesystemName)))
+                .baseUri();
     }
 
     static Configuration loadConfFromFile(Configuration conf, File confFile) throws MalformedURLException {

--- a/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/metrics/BenchmarkMetrics.java
+++ b/spark-tpcds-benchmark-runner/src/main/java/com/palantir/spark/benchmark/metrics/BenchmarkMetrics.java
@@ -73,7 +73,9 @@ public final class BenchmarkMetrics {
                         JacksonSerializer.create(BenchmarkMetric.class))
                 .createOrOpen();
         if (!this.metricsBuffer.isEmpty()) {
-            log.warn("Found unflushed metrics in the buffer; attempting to flush");
+            log.warn(
+                    "Found unflushed {} metrics in the buffer; attempting to flush",
+                    SafeArg.of("numMetrics", metricsBuffer.size()));
             flushMetrics();
         }
     }

--- a/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/datagen/GenSortTest.java
+++ b/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/datagen/GenSortTest.java
@@ -43,7 +43,7 @@ public final class GenSortTest extends AbstractLocalSparkTest {
         Path destinationDataDirectory = createTemporaryWorkingDir("data");
         HadoopConfiguration hadoopConfiguration = getHadoopConfiguration(destinationDataDirectory);
         FileSystem dataFileSystem = FileSystems.createFileSystem(
-                hadoopConfiguration.defaultFsBaseUri(), hadoopConfiguration.toHadoopConf());
+                hadoopConfiguration.dataFilesystemBaseUri(), hadoopConfiguration.toHadoopConf());
 
         BenchmarkPaths paths = new BenchmarkPaths("foo");
         int scale = 1;
@@ -69,13 +69,14 @@ public final class GenSortTest extends AbstractLocalSparkTest {
 
         List<String> generatedLines = read(
                 Paths.get(
-                        hadoopConfiguration.defaultFsBaseUri().getPath(), paths.tableCsvFile(scale, "gensort_data", 0)),
+                        hadoopConfiguration.dataFilesystemBaseUri().getPath(),
+                        paths.tableCsvFile(scale, "gensort_data", 0)),
                 "csv");
         assertThat(generatedLines).hasSize(numRecords);
 
         List<String> copiedParquet = read(
                 Paths.get(
-                        hadoopConfiguration.defaultFsBaseUri().getPath(),
+                        hadoopConfiguration.dataFilesystemBaseUri().getPath(),
                         paths.tableParquetLocation(scale, "gensort_data")),
                 "parquet");
         assertThat(copiedParquet).hasSameElementsAs(generatedLines);

--- a/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/datagen/TpcdsDataGeneratorIntegrationTest.java
+++ b/spark-tpcds-benchmark-runner/src/test/java/com/palantir/spark/benchmark/datagen/TpcdsDataGeneratorIntegrationTest.java
@@ -40,7 +40,7 @@ public final class TpcdsDataGeneratorIntegrationTest extends AbstractLocalSparkT
         Path destinationDataDirectory = createTemporaryWorkingDir("data");
         HadoopConfiguration hadoopConfiguration = getHadoopConfiguration(destinationDataDirectory);
         FileSystem dataFileSystem = FileSystems.createFileSystem(
-                hadoopConfiguration.defaultFsBaseUri(), hadoopConfiguration.toHadoopConf());
+                hadoopConfiguration.dataFilesystemBaseUri(), hadoopConfiguration.toHadoopConf());
 
         BenchmarkPaths paths = new BenchmarkPaths("foo");
         int scale = 1;
@@ -56,7 +56,7 @@ public final class TpcdsDataGeneratorIntegrationTest extends AbstractLocalSparkT
                 MoreExecutors.newDirectExecutorService());
         generator.generateData();
         try (Stream<Path> generatedCsvFiles = Files.list(
-                        Paths.get(hadoopConfiguration.defaultFsBaseUri().getPath(), paths.csvDir(scale)))
+                        Paths.get(hadoopConfiguration.dataFilesystemBaseUri().getPath(), paths.csvDir(scale)))
                 .filter(path -> path.toString().endsWith(".csv"))) {
             assertThat(generatedCsvFiles.count()).isEqualTo(25);
         }


### PR DESCRIPTION
## Before this PR
Everything gets read and written to the same filesystem

## After this PR
==COMMIT_MSG==
The data filesystem can be explicitly different from the default filesystem (so that, e.g., results/metrics may be written to default fs instead of data fs).
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

